### PR TITLE
Add relief column to trucks table and update related queries

### DIFF
--- a/Docker/setup.sql
+++ b/Docker/setup.sql
@@ -13,6 +13,7 @@ DROP TABLE IF EXISTS `locker_item_deletion_log`;
 CREATE TABLE `trucks` (
     `id` INT AUTO_INCREMENT PRIMARY KEY,
     `name` VARCHAR(255) NOT NULL
+    `relief` BOOLEAN NOT NULL DEFAULT FALSE
 );
 
 -- Create the `lockers` table

--- a/changeover2.php
+++ b/changeover2.php
@@ -1,5 +1,8 @@
 <?php
 
+    // ALTER TABLE `trucks` ADD COLUMN `relief` BOOLEAN NOT NULL DEFAULT FALSE;
+
+    
     include 'db.php';
 
 

--- a/index.php
+++ b/index.php
@@ -64,7 +64,8 @@ if ($colorBlindMode) {
 
 
 $db = get_db_connection();
-$trucks = $db->query('SELECT * FROM trucks')->fetchAll(PDO::FETCH_ASSOC);
+//$trucks = $db->query('SELECT * FROM trucks')->fetchAll(PDO::FETCH_ASSOC);
+$trucks = $db->query('SELECT id, name, relief FROM trucks')->fetchAll(PDO::FETCH_ASSOC);
 
 function get_locker_status($locker_id, $db, $colours) {
     // Fetch the most recent check for the locker
@@ -120,7 +121,8 @@ function convertToNZST($utcDate) {
                     <?php
                     $locker_status = get_locker_status($locker['id'], $db, $colours);
                     $locker_url = 'check_locker_items.php?truck_id=' . $truck['id'] . '&locker_id=' . $locker['id'];
-                    $background_color = $locker_status['status'];
+                    // Override background color if truck is relief
+                    $background_color = $truck['relief'] ? '#808080' : $locker_status['status'];
                     $text_color = 'white';
                     $last_checked = $locker_status['check'] ? $locker_status['check']['check_date'] : 'Never';
                     $last_checked_display = $last_checked !== 'Never' ? convertToNZST($last_checked) : $last_checked;


### PR DESCRIPTION
Introduce a new `relief` column in the `trucks` table and modify queries in `changeover2.php` and `index.php` to accommodate this change.